### PR TITLE
Renamed bind to register

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ import { myComponent } from "./myComponent";
 
 export const container = new Container();
 
-container.bind<bindings.INumbersDB>(bindings.NUMBERS_DB, numbersDB);
-container.bind<bindings.IMyComponent>(bindings.MY_COMPONENT, myComponent);
+container.register<bindings.INumbersDB>(bindings.NUMBERS_DB, numbersDB);
+container.register<bindings.IMyComponent>(bindings.MY_COMPONENT, myComponent);
 ```
 
 That's it! Now you've got a fully functional dependency injection container set up.  
@@ -148,7 +148,7 @@ export const controller: RequestHandler = async (req, res, next) => {
   const ctx = { correlationId: req.header("correlation-id") ?? "missing" };
   const myFavoriteNumber = await container
     .createChild()
-    .bind<IRequestContext>(REQUEST_CONTEXT, () => ctx)
+    .register<IRequestContext>(REQUEST_CONTEXT, () => ctx)
     .get<IMyComponent>(MY_COMPONENT)
     .getMyFavoriteNumber();
 
@@ -222,7 +222,7 @@ As you can see, there's nothing special to it. Easy-peasy!
 
 ## Container API
 
-### container.bind()
+### container.register()
 
 Register an id with a component in the container.
 
@@ -232,7 +232,7 @@ registered component matches the required interface.
 Example:
 
 ```ts
-container.bind<IMyComponent>(MY_COMPONENT, myComponent);
+container.register<IMyComponent>(MY_COMPONENT, myComponent);
 ```
 
 The registered binding can later be injected with the `inject` function like so:
@@ -245,29 +245,29 @@ It is suggested you keep your dependency ids and types close to each other,
 preferably in a separate `bindings` file. That makes them easy to use and improves
 maintainability.
 
-### container.isBound()
+### container.isRegistered()
 
-Check if there is a binding for a given id.
-This will check this container and also all of its parents.
+Check if there is a binding registered for a given id.
+This will check this container and also all of it's parents.
 
 Example:
 
 ```ts
-const myComponentIsBound = container.isBound(MY_COMPONENT);
+const myComponentIsRegistered = container.isRegistered(MY_COMPONENT);
 ```
 
-### container.isCurrentBound()
+### container.isRegisteredHere()
 
-Check if there is a binding for a given id.
+Check if there is a binding registered for a given id.
 This will check only this container.
 
 Example:
 
 ```ts
-const myComponentIsBound = container.isCurrentBound(MY_COMPONENT);
+const myComponentIsRegistered = container.isRegisteredHere(MY_COMPONENT);
 ```
 
-### container.unbind()
+### container.remove()
 
 Removes the binding for the given id.
 This will only remove it from this container.
@@ -275,7 +275,7 @@ This will only remove it from this container.
 Example:
 
 ```ts
-container.unbind(MY_COMPONENT);
+container.remove(MY_COMPONENT);
 ```
 
 ### container.get()
@@ -302,9 +302,9 @@ Creates and returns a child container.
 This is effectively the reverse of extending.
 The new container will have this container as the only parent.
 
-Child containers are very useful when you want to bind something for a single run,
-for example, if you've got request context you want to bind to the container before getting your component.
-Using child containers allows you to bind these temporary values without polluting the root container.
+Child containers are very useful when you want to register something for a single run,
+for example, if you've got request context you want to register to the container before getting your component.
+Using child containers allows you to register these temporary values without polluting the root container.
 
 Example:
 
@@ -348,10 +348,10 @@ declare type FactoryOf<T> = (inject: Inject) => T;
 
 declare class Container {
   parents: Container[];
-  bind<T>(id: ID, value: FactoryOf<T>): this;
-  isBound(id: ID): boolean;
-  isCurrentBound(id: ID): boolean;
-  unbind(id: ID): this;
+  register<T>(id: ID, value: FactoryOf<T>): this;
+  isRegistered(id: ID): boolean;
+  isRegisteredHere(id: ID): boolean;
+  remove(id: ID): this;
   get<T>(id: ID): T;
   extend(...containers: Container[]): this;
   createChild(): Container;

--- a/src/container.spec.ts
+++ b/src/container.spec.ts
@@ -17,9 +17,9 @@ describe("Container instance", () => {
     const container = new Container();
 
     it("should bind a component into the container", () => {
-      expect(container.isBound(ADDER)).toBe(false);
-      container.bind<Adder>(ADDER, adder);
-      expect(container.isBound(ADDER)).toBe(true);
+      expect(container.isRegistered(ADDER)).toBe(false);
+      container.register<Adder>(ADDER, adder);
+      expect(container.isRegistered(ADDER)).toBe(true);
     });
   });
 
@@ -36,15 +36,15 @@ describe("Container instance", () => {
     });
 
     const container = new Container();
-    container.bind<Adder>(ADDER, adder);
+    container.register<Adder>(ADDER, adder);
 
     it("return true if component is bound in the container", () => {
-      expect(container.isBound(ADDER)).toBe(true);
+      expect(container.isRegistered(ADDER)).toBe(true);
     });
 
     it("should return true if component is bound in the parent container", () => {
       const childContainer = container.createChild();
-      expect(childContainer.isBound(ADDER)).toBe(true);
+      expect(childContainer.isRegistered(ADDER)).toBe(true);
     });
   });
 
@@ -61,15 +61,15 @@ describe("Container instance", () => {
     });
 
     const container = new Container();
-    container.bind<Adder>(ADDER, adder);
+    container.register<Adder>(ADDER, adder);
 
     it("return true if component is bound in the container", () => {
-      expect(container.isCurrentBound(ADDER)).toBe(true);
+      expect(container.isRegisteredHere(ADDER)).toBe(true);
     });
 
     it("should return false if component is bound in the parent container", () => {
       const childContainer = container.createChild();
-      expect(childContainer.isCurrentBound(ADDER)).toBe(false);
+      expect(childContainer.isRegisteredHere(ADDER)).toBe(false);
     });
   });
 
@@ -87,35 +87,35 @@ describe("Container instance", () => {
 
     it("should unbind the component from the container", () => {
       const container = new Container();
-      container.bind<Adder>(ADDER, adder);
+      container.register<Adder>(ADDER, adder);
 
-      expect(container.isBound(ADDER)).toBe(true);
-      container.unbind(ADDER);
-      expect(container.isBound(ADDER)).toBe(false);
+      expect(container.isRegistered(ADDER)).toBe(true);
+      container.remove(ADDER);
+      expect(container.isRegistered(ADDER)).toBe(false);
     });
 
     it("should not unbind the component from a parent container", () => {
       const container = new Container();
-      container.bind<Adder>(ADDER, adder);
+      container.register<Adder>(ADDER, adder);
       const childContainer = container.createChild();
 
-      expect(childContainer.isBound(ADDER)).toBe(true);
-      childContainer.unbind(ADDER);
-      expect(childContainer.isBound(ADDER)).toBe(true);
-      expect(childContainer.isCurrentBound(ADDER)).toBe(false);
+      expect(childContainer.isRegistered(ADDER)).toBe(true);
+      childContainer.remove(ADDER);
+      expect(childContainer.isRegistered(ADDER)).toBe(true);
+      expect(childContainer.isRegisteredHere(ADDER)).toBe(false);
     });
 
     it("should not unbind other components from the container", () => {
       const ADDER2 = Symbol.for("adder2");
       const container = new Container();
-      container.bind<Adder>(ADDER, adder);
-      container.bind<Adder>(ADDER2, adder);
+      container.register<Adder>(ADDER, adder);
+      container.register<Adder>(ADDER2, adder);
 
-      expect(container.isBound(ADDER)).toBe(true);
-      expect(container.isBound(ADDER2)).toBe(true);
-      container.unbind(ADDER);
-      expect(container.isBound(ADDER)).toBe(false);
-      expect(container.isBound(ADDER2)).toBe(true);
+      expect(container.isRegistered(ADDER)).toBe(true);
+      expect(container.isRegistered(ADDER2)).toBe(true);
+      container.remove(ADDER);
+      expect(container.isRegistered(ADDER)).toBe(false);
+      expect(container.isRegistered(ADDER2)).toBe(true);
     });
   });
 
@@ -143,10 +143,10 @@ describe("Container instance", () => {
         return { num2: 5 };
       };
 
-      // Component bindings
+      // Component registrations
       const container = new Container();
-      container.bind<Adder>(ADDER, adder);
-      container.bind<NumberCarrier>(NUMBER_CARRIER, numberCarrier);
+      container.register<Adder>(ADDER, adder);
+      container.register<NumberCarrier>(NUMBER_CARRIER, numberCarrier);
 
       it("should find a known component", () => {
         const component = container.get<Adder>(ADDER);
@@ -188,10 +188,10 @@ describe("Container instance", () => {
         return { getNum2 };
       };
 
-      // Component bindings
+      // Component registrations
       const container = new Container();
-      container.bind<Adder>(ADDER, adder);
-      container.bind<NumberCarrier>(NUMBER_CARRIER, numberCarrier);
+      container.register<Adder>(ADDER, adder);
+      container.register<NumberCarrier>(NUMBER_CARRIER, numberCarrier);
 
       it("should find a known component", () => {
         const component = container.get<Adder>(ADDER);
@@ -234,18 +234,18 @@ describe("Container instance", () => {
       baguette: 5,
     });
 
-    // Container bindings
+    // Container registrations
     const baseContainer1 = new Container();
-    baseContainer1.bind<Messages>(MESSAGES, messages);
+    baseContainer1.register<Messages>(MESSAGES, messages);
     const baseContainer2 = new Container();
-    baseContainer2.bind<Numbers>(NUMBERS, numbers);
+    baseContainer2.register<Numbers>(NUMBERS, numbers);
 
     describe("when extended with 2 containers, separately", () => {
       const container = new Container();
       container.extend(baseContainer1);
       container.extend(baseContainer2);
       container.extend(baseContainer1); // This is used to test the uniqueness
-      container.bind<Breads>(BREADS, breads);
+      container.register<Breads>(BREADS, breads);
 
       it("should push provided unique containers to the parents array", () => {
         expect(container.parents).toStrictEqual([
@@ -291,9 +291,9 @@ describe("Container instance", () => {
       PI: 3.14,
     });
 
-    // Root container component bindings
+    // Root container component registrations
     const container = new Container();
-    container.bind<Messages>(MESSAGES, messages);
+    container.register<Messages>(MESSAGES, messages);
     const childContainer = container.createChild();
 
     it("should return a new container", () => {
@@ -301,7 +301,7 @@ describe("Container instance", () => {
     });
 
     describe("grandchild container", () => {
-      childContainer.bind<Numbers>(NUMBERS, numbers);
+      childContainer.register<Numbers>(NUMBERS, numbers);
       const grandChildContainer = childContainer.createChild();
 
       it("should find components from the original parent container", () => {

--- a/src/container.ts
+++ b/src/container.ts
@@ -37,7 +37,7 @@ export class Container {
    *
    * Example:
    * ```ts
-   * container.bind<IMyComponent>(MY_COMPONENT, myComponent)
+   * container.register<IMyComponent>(MY_COMPONENT, myComponent)
    * ```
    * ---
    * The registered binding can later be injected with the `inject` function like so:
@@ -48,37 +48,37 @@ export class Container {
    * preferably in a separate `bindings` file. That makes them easy to use and improves
    * maintainability.
    */
-  public bind<T>(id: ID, value: FactoryOf<T>): this {
+  public register<T>(id: ID, value: FactoryOf<T>): this {
     this.bindings.set(id, value);
     return this;
   }
 
   /**
-   * Check if there is a binding for a given id.
+   * Check if there is a binding registered for a given id.
    * This will check this container and also all of it's parents.
    *
    * Example:
    * ```ts
-   * const myComponentIsBound = container.isBound(MY_COMPONENT)
+   * const myComponentIsRegistered = container.isRegistered(MY_COMPONENT)
    * ```
    */
-  public isBound(id: ID): boolean {
+  public isRegistered(id: ID): boolean {
     return (
-      this.isCurrentBound(id) ||
-      this.parents.some((parent) => parent.isBound(id))
+      this.isRegisteredHere(id) ||
+      this.parents.some((parent) => parent.isRegistered(id))
     );
   }
 
   /**
-   * Check if there is a binding for a given id.
+   * Check if there is a binding registered for a given id.
    * This will check only this container.
    *
    * Example:
    * ```ts
-   * const myComponentIsBound = container.isCurrentBound(MY_COMPONENT)
+   * const myComponentIsRegistered = container.isRegisteredHere(MY_COMPONENT)
    * ```
    */
-  public isCurrentBound(id: ID): boolean {
+  public isRegisteredHere(id: ID): boolean {
     return this.bindings.has(id);
   }
 
@@ -88,10 +88,10 @@ export class Container {
    *
    * Example:
    * ```ts
-   * container.unbind(MY_COMPONENT)
+   * container.remove(MY_COMPONENT)
    * ```
    */
-  public unbind(id: ID): this {
+  public remove(id: ID): this {
     this.bindings.delete(id);
     return this;
   }


### PR DESCRIPTION
Renamed the following methods to make the API easier to understand:
bind -> register
isBound -> isRegistered
isCurrentBound -> isRegisteredHere
unbind -> remove

Also updated documentation to reflect the change